### PR TITLE
Allow the embedded driver to be used on macOS

### DIFF
--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -187,10 +187,6 @@ def configure(env: "SConsEnvironment"):
             env.Append(CCFLAGS=["-fsanitize=thread"])
             env.Append(LINKFLAGS=["-fsanitize=thread"])
 
-        env.Append(LINKFLAGS=["-Wl,-stack_size," + hex(STACK_SIZE_SANITIZERS)])
-    else:
-        env.Append(LINKFLAGS=["-Wl,-stack_size," + hex(STACK_SIZE)])
-
     if env["use_coverage"]:
         env.Append(CCFLAGS=["-ftest-coverage", "-fprofile-arcs"])
         env.Append(LINKFLAGS=["-ftest-coverage", "-fprofile-arcs"])

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -39,6 +39,7 @@
 #include "core/crypto/crypto_core.h"
 #include "core/version_generated.gen.h"
 #include "main/main.h"
+#include "servers/display_server_embedded.h"
 
 #include <dlfcn.h>
 #include <libproc.h>
@@ -828,6 +829,7 @@ OS_MacOS::OS_MacOS() {
 #endif
 
 	DisplayServerMacOS::register_macos_driver();
+	DisplayServerEmbedded::register_embedded_driver();
 
 	// Implicitly create shared NSApplication instance.
 	[GodotApplication sharedApplication];

--- a/servers/display_server_embedded.cpp
+++ b/servers/display_server_embedded.cpp
@@ -306,7 +306,7 @@ bool DisplayServerEmbedded::has_feature(Feature p_feature) const {
 		// case FEATURE_HIDPI:
 		// case FEATURE_ICON:
 		// case FEATURE_IME:
-		// case FEATURE_MOUSE:
+		case FEATURE_MOUSE:
 		// case FEATURE_MOUSE_WARP:
 		// case FEATURE_NATIVE_DIALOG:
 		// case FEATURE_NATIVE_ICON:
@@ -601,4 +601,21 @@ void DisplayServerEmbedded::gl_window_make_current(DisplayServer::WindowID p_win
 	}
 	current_window = p_window_id;
 #endif
+}
+
+void DisplayServerEmbedded::mouse_set_mode(DisplayServer::MouseMode p_mode) {
+
+}
+
+DisplayServer::MouseMode DisplayServerEmbedded::mouse_get_mode() const {
+return MOUSE_MODE_VISIBLE;
+}
+	
+Point2i DisplayServerEmbedded::mouse_get_position() const {
+	return Input::get_singleton()->get_mouse_position();
+}
+
+// This isn't really called (see Input.cpp) but it needs overriden
+BitField<MouseButtonMask> DisplayServerEmbedded::mouse_get_button_state() const {
+	return Input::get_singleton()->get_mouse_button_mask();
 }

--- a/servers/display_server_embedded.h
+++ b/servers/display_server_embedded.h
@@ -200,6 +200,11 @@ public:
 	void set_content_scale(float p_scale);
 	virtual void swap_buffers() override;
 	virtual void gl_window_make_current(DisplayServer::WindowID p_window_id) override;
+
+	virtual void mouse_set_mode(MouseMode p_mode) override;
+	virtual MouseMode mouse_get_mode() const override;
+	virtual Point2i mouse_get_position() const override;
+	virtual BitField<MouseButtonMask> mouse_get_button_state() const override;
 };
 
 #endif // DISPLAY_SERVER_EMBEDDED_H


### PR DESCRIPTION
* Allow the embedded driver to be an option on macOS
* Add mouse support to the embedded driver

Using this branch of SwiftGodotKit: https://github.com/iainx/SwiftGodotKit/tree/iain/mouse-support which has mouse/keyboard support on macOS to embed godot inside a macOS window, rather than a separate window.